### PR TITLE
chore: bump ssp-relay-dashboard submodule (CMS analytics) + gitignore planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,7 @@ dist
 !.yarn/patches/
 !.yarnrc.yml
 !.pnp.cjs
+
+# Local planning artifacts (specs, plans) — not tracked in git
+docs/superpowers/
+


### PR DESCRIPTION
## Summary

Two small chores:

1. **Bump `ssp-relay-dashboard` submodule** from `7da6bc8` to `43ad69b` — picks up the merge of [ssp-relay-dashboard#19](https://github.com/RunOnFlux/ssp-relay-dashboard/pull/19), which adds:
   - `/cms/analytics` page in the Content sidebar with five tabs (Overview · Search · Pages · Opportunities · Decay).
   - GA4 + Google Search Console service layer + 8 new API routes under \`/api/analytics/*\`.
   - Server-side join between CMS posts and GSC/GA4 page rows so editors can see per-post performance.
   - New \`cms-analytics\` \`DashboardSection\` permission (default: read for owner/admin, none for viewer).
   - Operator setup guide at \`ssp-relay-dashboard/docs/analytics-setup.md\`.

2. **Gitignore \`docs/superpowers/\`** — local planning artifacts (specs, plans) used during the analytics work; not project documentation, shouldn't be tracked.

## Required env vars before \`/cms/analytics\` shows real data

Set these on whatever deploys the dashboard:

\`\`\`
GOOGLE_SERVICE_ACCOUNT_EMAIL
GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY  # base64-encoded PEM
GOOGLE_ANALYTICS_PROPERTY_ID
GOOGLE_SEARCH_CONSOLE_SITE_URL      # sc-domain:... or https://...
\`\`\`

Service-account needs: GA4 "Viewer" on the property and GSC "Restricted" on the site. Full setup steps in \`ssp-relay-dashboard/docs/analytics-setup.md\` once merged.

## Test plan

- [x] Submodule SHA matches \`main\` tip on RunOnFlux/ssp-relay-dashboard
- [x] All upstream PR CI checks passed (lint, type-check, tests, build — 146 tests)
- [ ] After merge: \`git submodule update --init --recursive\` resolves cleanly
- [ ] After deploy with env vars set: \`/cms/analytics\` loads and KPI cards populate